### PR TITLE
Add basic support for generating an `IOApp.Simple`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,32 @@
+# base
 *.class
 *.log
+
+# sbt specific
+.cache/
+.history/
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+.vscode/
+.bloop/
+.bsp/
+.metals/
+.ensime_cache/
+*metals.sbt
+.idea
+_site/
+
+# mac
+.DS_Store
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Library for use with the `dc10-scala` code generator
  - Library for Scala 3 (JVM only)
 
 ```scala
-"com.julianpeeters" %% "dc10-cats-effect" % "0.0.0"
+"com.julianpeeters" %% "dc10-cats-effect" % "0.1.0"
 ```
 
 ### Usage
@@ -23,7 +23,7 @@ val snippet =
       IO.PRINTLN("Hello, World!")
     )
   )
-// snippet: IndexedStateT[ErrorF, List[Statement], List[Statement], ValueExpr[IO[Unit]]] = cats.data.IndexedStateT@4a77a414
+// snippet: IndexedStateT[ErrorF, List[Statement], List[Statement], ValueExpr[IO[Unit]]] = cats.data.IndexedStateT@dfdf230
 ```
 
 Use the compiler in `dc10-scala` to render code `toString` or `toVirtualFile`:

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,51 @@
+val Dc10ScalaV = "0.3.0"
+val MUnitV = "0.7.29"
+
+inThisBuild(List(
+  crossScalaVersions := Seq(scalaVersion.value),
+  description := "Library for use with the `dc10-scala` code generator",
+  organization := "com.julianpeeters",
+  homepage := Some(url("https://github.com/julianpeeters/dc10-cats-effect")),
+  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  developers := List(
+    Developer(
+      "julianpeeters",
+      "Julian Peeters",
+      "julianpeeters@gmail.com",
+      url("http://github.com/julianpeeters")
+    )
+  ),
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-feature",
+    "-Werror",
+    "-source:future",
+    "-Wunused:all",
+    "-Wvalue-discard"
+  ),
+  scalaVersion := "3.3.1",
+  versionScheme := Some("semver-spec"),
+))
+
+lazy val `dc10-cats-effect` = (project in file("."))
+  .settings(
+    name := "dc10-cats-effect",
+    libraryDependencies ++= Seq(
+      // main
+      "com.julianpeeters" %% "dc10-scala" % Dc10ScalaV,
+      // test
+      "org.scalameta" %% "munit" % MUnitV % Test
+    )
+  )
+
+lazy val docs = project.in(file("docs/gitignored"))
+  .settings(
+    mdocOut := `dc10-cats-effect`.base,
+    mdocVariables := Map(
+      "SCALA" -> crossScalaVersions.value.map(e => e.takeWhile(_ != '.')).mkString(", "),
+      "VERSION" -> version.value.takeWhile(_ != '+'),
+    )
+  )
+  .dependsOn(`dc10-cats-effect`)
+  .enablePlugins(MdocPlugin)
+  .enablePlugins(NoPublishPlugin)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,17 +2,17 @@
 Library for use with the `dc10-scala` code generator
 
 ### Getting Started
- - Library for Scala 3 (JVM only)
+ - Library for Scala @SCALA@ (JVM only)
 
 ```scala
-"com.julianpeeters" %% "dc10-cats-effect" % "0.0.0"
+"com.julianpeeters" %% "dc10-cats-effect" % "@VERSION@"
 ```
 
 ### Usage
 
 Use the dsl to define scala code that depends on cats-effect:
 
-```scala
+```scala mdoc
 import dc10.cats.effect.dsl.*
 import dc10.scala.dsl.given               // for strings, e.g., "Hello, World!"
 import scala.language.implicitConversions // for literals, e.g., "Hello, World!"
@@ -23,17 +23,13 @@ val snippet =
       IO.PRINTLN("Hello, World!")
     )
   )
-// snippet: IndexedStateT[ErrorF, List[Statement], List[Statement], ValueExpr[IO[Unit]]] = cats.data.IndexedStateT@4a77a414
 ```
 
 Use the compiler in `dc10-scala` to render code `toString` or `toVirtualFile`:
 
-```scala
+```scala mdoc
 import dc10.scala.compiler.{compile, toString}
 import dc10.scala.version.`3.3.1`
 
 val result: String = snippet.compile.toString["scala-3.3.1"]
-// result: String = """object HelloWorld extends cats.effect.IOApp.Simple:
-// 
-//   val run: cats.effect.IO[Unit] = IO.println("Hello, World!")"""
 ```

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7" )
+addSbtPlugin("org.typelevel" % "sbt-typelevel-no-publish" % "0.5.1" )

--- a/src/main/scala/dc10/cats/effect/CatsEffect.scala
+++ b/src/main/scala/dc10/cats/effect/CatsEffect.scala
@@ -1,0 +1,63 @@
+package dc10.cats.effect
+
+import cats.data.StateT
+import cats.Eval
+import cats.free.Cofree
+import dc10.scala.Statement
+import dc10.scala.ctx.{ErrorF, ext}
+import org.tpolecat.sourcepos.SourcePos
+import dc10.scala.Statement.ValueExpr
+import dc10.scala.Statement.{ObjectDef, ValueDef}
+import dc10.scala.Symbol.{Object, Term}
+import dc10.scala.Symbol.Term.TypeLevel.__
+import dc10.scala.Statement.TypeExpr
+
+trait CatsEffect[F[_]]:
+  type IO[_]
+  type IOAPP
+  def IO: F[TypeExpr[IO[__]]]
+  def Io[A]: F[ValueExpr[IO[A] => IO[A]]]
+  extension [A] (io: F[ValueExpr[IO[A] => IO[A]]])
+    @scala.annotation.targetName("appVIO")
+    def apply(arg: F[ValueExpr[A]]): F[ValueExpr[IO[A]]]
+  def IOAPP(name: String, run: F[ValueExpr[IO[Unit]]])(using sp: SourcePos): F[ValueExpr[IO[Unit]]]
+  def RUN(program: F[ValueExpr[IO[Unit]]]): F[ValueExpr[IO[Unit]]]
+  extension (io: F[TypeExpr[IO[__]]])
+    def PRINTLN(msg: F[ValueExpr[String]]): F[ValueExpr[IO[Unit]]]
+
+object CatsEffect:
+
+  trait Mixins extends CatsEffect[[A] =>> StateT[ErrorF, List[Statement], A]]:
+    def IO: StateT[ErrorF, List[Statement], TypeExpr[IO[__]]] =
+      StateT.pure(TypeExpr(Cofree((), Eval.now(Term.TypeLevel.Var.UserDefinedType(None, "IO", None)))))
+    def Io[A]: StateT[ErrorF, List[Statement], ValueExpr[IO[A] => IO[A]]] =
+      ???
+    extension [A] (io: StateT[ErrorF, List[Statement], ValueExpr[IO[A] => IO[A]]])
+      @scala.annotation.targetName("appVIO")
+      def apply(arg: StateT[ErrorF, List[Statement], ValueExpr[A]]): StateT[ErrorF, List[Statement], ValueExpr[IO[A]]] =
+        ???
+    def IOAPP(
+      name: String,
+      run: StateT[ErrorF, List[Statement], ValueExpr[IO[Unit]]]
+    )(using sp: SourcePos): StateT[ErrorF, List[Statement], ValueExpr[IO[Unit]]] =
+      for
+        (c, r) <- StateT.liftF[ErrorF, List[Statement], (List[Statement], ValueExpr[IO[Unit]])](run.runEmpty)
+        o <- StateT.pure[ErrorF, List[Statement], Object[IOAPP]](Object(None, name, Some(Cofree((), Eval.now(Term.TypeLevel.Var.UserDefinedType(None, "cats.effect.IOApp.Simple", None)))), c.map(s => s.addIndent)))
+        d <- StateT.pure[ErrorF, List[Statement], ObjectDef](ObjectDef(o, 0))
+        _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
+      yield r
+
+    def RUN(program: StateT[ErrorF, List[Statement], ValueExpr[IO[Unit]]]): StateT[ErrorF, List[Statement], ValueExpr[IO[Unit]]] =
+      for
+        i <- StateT.liftF(program.runEmptyA)
+        v <- StateT.pure(Term.ValueLevel.Var.UserDefinedValue(None, "run", i.value.tail.value.tpe, Some(i.value)))
+        d <- StateT.pure[ErrorF, List[Statement], ValueDef](ValueDef.Val(0, v))
+        _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
+      yield i
+  
+    extension (io: StateT[ErrorF, List[Statement], TypeExpr[IO[__]]])
+      def PRINTLN(msg: StateT[ErrorF, List[Statement], ValueExpr[String]]): StateT[ErrorF, List[Statement], ValueExpr[IO[Unit]]] =
+        for
+          s <- StateT.liftF(msg.runEmptyA)
+          v <- StateT.pure[ErrorF, List[Statement], Term.Value[IO[Unit]]](Cofree((), Eval.now(Term.ValueLevel.Var.Println(None, s.value))))
+        yield ValueExpr(v)

--- a/src/main/scala/dc10/cats/effect/dsl.scala
+++ b/src/main/scala/dc10/cats/effect/dsl.scala
@@ -1,0 +1,7 @@
+package dc10.cats.effect
+
+trait dsl
+
+object dsl extends dsl
+  with CatsEffect.Mixins
+

--- a/src/test/scala/dc10/cats/effect/CatsEffectSuit.scala
+++ b/src/test/scala/dc10/cats/effect/CatsEffectSuit.scala
@@ -1,0 +1,25 @@
+package dc10.cats.effect
+
+import dc10.cats.effect.dsl.*
+import dc10.scala.compiler.{compile, toString}
+import dc10.scala.dsl.given
+import dc10.scala.version.`3.3.1`
+import scala.language.implicitConversions
+
+import munit.FunSuite
+
+class CatsEffectSuit extends FunSuite:
+
+  test("ioapp val"):
+
+    def ast = IOAPP("HelloWorld", RUN(IO.PRINTLN("Hello, World!")))
+    
+    val obtained: String =
+      ast.compile.toString["scala-3.3.1"]
+      
+    val expected: String =
+      """object HelloWorld extends cats.effect.IOApp.Simple:
+        |
+        |  val run: cats.effect.IO[Unit] = IO.println("Hello, World!")""".stripMargin
+      
+    assertEquals(obtained, expected)


### PR DESCRIPTION
starting out with a `def run` that takes an `IO[Unit]`.